### PR TITLE
Allows For Multiple Query Parameters

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,5 +5,5 @@ export function handleLoginRedirect(
 	message: string = "You must be logged in to access this page"
 ) {
 	const redirectTo = event.url.pathname + event.url.search
-	return `/login?redirectTo=${redirectTo}&message=${message}`
+	return `/login?redirectTo=${encodeURIComponent(redirectTo)}&message=${message}`
 }


### PR DESCRIPTION
When multiple query parameters are provided without URI encoding only the first will be present once redirected.

A redirectTo such as `/account?something=something&another=another` when not properly encoded will resolve to `/account?something=something` when redirected.

This adds a `encodeURIComponent` to wrap the redirectTo allowing for multiple query parameters to be maintained when redirected.